### PR TITLE
[FIX] Upgrade Android sdk version to 1.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@
 * 
 ## 0.0.5
 
-* Upgrade android crispt native sdk to 1.0.11.
+* Upgrade android crisp native sdk to 1.0.11.
 
-* ## 0.0.6
+## 0.0.6
 
 * Change android target version to 33.
+
+## 0.0.7
+
+* Upgrade android crisp native sdk to 1.0.13 to solve https://github.com/crisp-im/crisp-sdk-android/issues/116.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,6 +48,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'im.crisp:crisp-sdk:1.0.11'
+    implementation 'im.crisp:crisp-sdk:1.0.13'
     implementation 'androidx.multidex:multidex:2.0.1'
 }


### PR DESCRIPTION
It fixes this issue: https://github.com/crisp-im/crisp-sdk-android/issues/116.
I got many of them in my logs and it finds out that it has been fixed by Crisp.
Also fixed typos in docs