### PR TITLE
don't fix android crisp minor and patch versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,6 +48,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'im.crisp:crisp-sdk:1.0.11'
+    implementation 'im.crisp:crisp-sdk:1.+'
     implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/android/src/main/kotlin/crisp/chat/sdk/crisp_chat_sdk/CrispChatSdkPlugin.kt
+++ b/android/src/main/kotlin/crisp/chat/sdk/crisp_chat_sdk/CrispChatSdkPlugin.kt
@@ -45,7 +45,7 @@ class CrispChatSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             Crisp.configure(context, call.arguments.toString())
             result.success("Android Crisp sdk initialized successful");
         } else if (call.method == "setTokenID") {
-            Crisp.setTokenID(call.arguments.toString())
+            Crisp.setTokenID(context, call.arguments.toString())
             result.success("Android Crisp sdk setTokenID successful");
         } else if (call.method == "resetChatSession") {
             Crisp.resetChatSession(context)


### PR DESCRIPTION
The iOS part of the plugin is using an unbounded dependency on the Crisp iOS SDK, not even locking the major version (it might be worth fixing that as well to avoid any breaking changes from any subsequent major updates)

The Android part had a fixed dependency on 1.0.11, which I could not understand why and it seems to be working fine with the most recent version (1.0.14) so I figured it'd be good to keep the minor and patch versions free as well.

If there _was_ a reason to keep it fixed to 1.0.11 feel free to ignore the PR but I would still appreciate it if you can provide the reason as ideally the plugin can be in sync with the latest official SDK versions.